### PR TITLE
Make compatible with latest rollup. Fixes #1.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,8 +29,10 @@ export default (opts) => {
 		},
 
 		ongenerate(opts, bundle) {
+			let modules = Array.isArray(bundle.modules) ? bundle.modules 
+														: Object.getOwnPropertyNames(bundle.modules)
 			let css = Object.entries(styles)
-				.sort((a, b) => bundle.modules.indexOf(a[0]) - bundle.modules.indexOf(b[0]))
+				.sort((a, b) => modules.indexOf(a[0]) - modules.indexOf(b[0]))
 				.map(entry => entry[1])
 				.join('\n');
 			bundles[opts.file] = css;

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ export default (opts) => {
 
 		ongenerate(opts, bundle) {
 			let modules = Array.isArray(bundle.modules) ? bundle.modules 
-														: Object.getOwnPropertyNames(bundle.modules)
+			                                            : Object.getOwnPropertyNames(bundle.modules)
 			let css = Object.entries(styles)
 				.sort((a, b) => modules.indexOf(a[0]) - modules.indexOf(b[0]))
 				.map(entry => entry[1])


### PR DESCRIPTION
This plugin did not work with the latest rollup due changes in the signature the signature for `ongenerate`(see [here](https://github.com/rollup/rollup/commit/2b0b6c9715c8f675927519f90667c9171f3e8a6a#diff-c5fd8e65630bd641bf07130346ee8778)). Rather than an array, an object is used to store modules. Hence issue #1 occurs.

`Object.keys` would not work, as we cannot guarantee the proper order of keys. However, in case the keys of the object are strings, `Object.getOwnPropertyNames` should yield keys in property creation order (see [link](https://stackoverflow.com/questions/30076219/does-es6-introduce-a-well-defined-order-of-enumeration-for-object-properties)).  Using this method we can restore functionality of this plugin for recent versions of rollup.

Let me know what you think. I haven't tested this thoroughly, but for my project it works fine.
